### PR TITLE
chore: readme update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,29 @@
-# The url base of the organization in Modyo
+# For deploying your project to Modyo and integrating it with your CI/CD pipeline
+# rename this file to ".env" and update the values with your own configuration.
+
+# Find more information on:
+# - Modyo Docs https://docs.modyo.com
+# - Modyo Community https://www.modyo.com/community
+
+
+# Base URL of your Modyo organization
 MODYO_ACCOUNT_URL=https://my-org.modyo.cloud/
-# Where you will deploy your micro frontend, you can use either the host or the ID but not both.
+
+# Either the host or the ID where you will deploy your micro frontend (not both)
 # MODYO_SITE_HOST=my-site
 MODYO_SITE_ID=65
-# The token authorizing the deployment, taken from Modyo
-MODYO_TOKEN=gT0ogW43lSy4nV9cYtc_hH0i_sUNq01q-12ptFzoW8
-# The major version of the Modyo platform where the deployment will take place (8, 9 or 10)
-MODYO_VERSION=10
-# The name of the directory that contains the bundle of the micro frontend
-MODYO_BUILD_DIRECTORY=build
-# The name that will identify your Micro Frontend in Modyo
-MODYO_WIDGET_NAME=my-project
-# This directive is necessary to safely remove some libraries from the liquid parser
+
+# Token for authorizing the deployment, obtained from Modyo
+TOKEN=gT0ogV43LSy4nV9cYtc_hH0i_rUFa01q-12ptFzoW8
+
+# Major version of the Modyo platform where the deployment will take place (8 or 9)
+VERSION=9
+
+# Directory containing the micro frontend bundle
+BUILD_DIRECTORY=build
+
+# Name to identify your Micro Frontend in Modyo
+WIDGET_NAME=my-project
+
+# Directive necessary for safely removing some libraries from the liquid parser
 MODYO_DISABLE_LIQUID_REGEX=raw
-# The port where local widget is running
-MODYO_LOCAL_PORT=8080
-# The container id where local widget is running
-MODYO_LOCAL_DOM_ID=widgetName
-# The main script of the local widget running
-MODYO_LOCAL_ENTRY_JS=main.js

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # dynamic-react-base-template
 ## Requirements:
-- Node@18+
-- npm@9+
+- Node@20+
+- npm@10+
 - @modyo/cli@latest
 
 ## Installation and initial setup
 The best way to install this template is using the [modyo-cli](https://docs.modyo.com/en/platform/channels/cli.html)
+
 ```console
 npx @modyo/cli@latest get dynamic-react-base-template my-project
 cd my-project
@@ -15,26 +16,38 @@ npm run start
 
 ### Setup
 1. Change the property name in `package.json` to the name of your project
-2. Change the root `id` in `public/index.html:36` and `src/index.tsx:16`
+2. Change the root `id` property to your project name in `public/index.html` and `src/index.tsx`
 
 **Note**: The root id should be _unique_ in your site and it should be written in camelCase.
 
 ## Deployment to Modyo and CI
-To be able to deploy to Modyo configure the following variables in an `.env` file or as part of the Continuous Integration:
+For deploying your project to Modyo and integrating it with your CI/CD pipeline, follow these steps:
+
+Configure the necessary environment variables in an `.env` file or as part of your CI settings:
+
 ```yaml
-# The url base of the organization in Modyo
+# Base URL of your Modyo organization
 MODYO_ACCOUNT_URL=https://my-org.modyo.cloud/
-# Where you will deploy your micro frontend, you can use either the host or the ID but not both.
+
+#Either the host or the ID where you will deploy your micro frontend (not both)
 # MODYO_SITE_HOST=my-site
 MODYO_SITE_ID=65
-# The token authorizing the deployment, taken from Modyo
-TOKEN=gT0ogW43lSy4nV9cYtc_hH0i_sUNq01q-12ptFzoW8
-# The major version of the Modyo platform where the deployment will take place (8 or 9)
+
+# Token for authorizing the deployment, obtained from Modyo
+TOKEN=gT0ogV43LSy4nV9cYtc_hH0i_rUFa01q-12ptFzoW8
+
+# Major version of the Modyo platform where the deployment will take place (8 or 9)
 VERSION=9
-# The name of the directory that contains the bundle of the micro frontend
+
+# Directory containing the micro frontend bundle
 BUILD_DIRECTORY=build
-# The name that will identify your Micro Frontend in Modyo
+
+# Name to identify your Micro Frontend in Modyo
 WIDGET_NAME=my-project
-# This directive is necessary to safely remove some libraries from the liquid parser
+
+# Directive necessary for safely removing some libraries from the liquid parser
 MODYO_DISABLE_LIQUID_REGEX=raw
 ```
+
+## Learn More
+Find more information about microfrontends and configuration details on [Modyo Docs](https://docs.modyo.com) & [Modyo Community](https://www.modyo.com/community)


### PR DESCRIPTION
This is a minor change with a revision to align the text to the Modyo guideline and to include links to documentation.

Changes:
 - Updated Node versions required to display Node LTS (20.12).
 - Updated NPM versions required to display the Node LTS companion version.
 - Removed line numbers in the prompts because they were incorrect and difficult to maintain.
 - Revised the environment variable information text to follow Modyo guidelines.
 - Included links to documentation